### PR TITLE
[fix] issues23,  分组拦截，登录接口不拦截, 配置了退出登录接口不拦截

### DIFF
--- a/gtoken/gtoken.go
+++ b/gtoken/gtoken.go
@@ -332,10 +332,10 @@ func (m *GfToken) AuthPath(urlPath string) bool {
 	if strings.HasSuffix(urlPath, "/") {
 		urlPath = gstr.SubStr(urlPath, 0, len(urlPath)-1)
 	}
-	// 分组拦截，登录接口不拦截
+	// 分组拦截，登录接口不拦截, 配置了退出登录接口不拦截
 	if m.MiddlewareType == MiddlewareTypeGroup {
 		if gstr.HasSuffix(urlPath, m.LoginPath) ||
-			gstr.HasSuffix(urlPath, m.LogoutPath) {
+			(m.LogoutPath != "" && gstr.HasSuffix(urlPath, m.LogoutPath)) {
 			return false
 		}
 	}


### PR DESCRIPTION
增加了对退出登录判断，非空判断通过则不拦截。

修改前有一个用例失败
=== RUN   TestGroupAuthPath
    gtoken_test.go:41: Group auth path test 
    gtoken_test.go:67: error: /system/test auth path error
--- FAIL: TestGroupAuthPath (0.00s)
FAIL

修改后
=== RUN   TestGroupAuthPath
    gtoken_test.go:41: Group auth path test 
--- PASS: TestGroupAuthPath (0.00s)
PASS